### PR TITLE
Support request timeouts

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -713,9 +713,15 @@ struct fuse_conn_info {
 	uint64_t want_ext;
 
 	/**
+	* Request timeout (in seconds). If the request is not answered by
+	* this timeout, the connection will be aborted by the kernel.
+	*/
+	uint16_t request_timeout;
+
+	/**
 	 * For future use.
 	 */
-	uint32_t reserved[16];
+	uint16_t reserved[31];
 };
 fuse_static_assert(sizeof(struct fuse_conn_info) == 128,
 		   "Size of struct fuse_conn_info must be 128 bytes");

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2289,6 +2289,11 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 	if (se->conn.want_ext & FUSE_CAP_NO_EXPORT_SUPPORT)
 		outargflags |= FUSE_NO_EXPORT_SUPPORT;
 
+	if ((inargflags & FUSE_REQUEST_TIMEOUT) && se->conn.request_timeout) {
+		outargflags |= FUSE_REQUEST_TIMEOUT;
+		outarg.request_timeout = se->conn.request_timeout;
+	}
+
 	if (inargflags & FUSE_INIT_EXT) {
 		outargflags |= FUSE_INIT_EXT;
 		outarg.flags2 = outargflags >> 32;


### PR DESCRIPTION
Support request timeouts

This adds the libfuse changes needed to support request timeouts.
A timeout may be set by the server in its init call. If a request is not
completed by the timeout, the connection will be aborted by the kernel.

Signed-off-by: Joanne Koong <joannelkoong@gmail.com>